### PR TITLE
touchscreen support (rotate/zoom) for `viewer.rs`, and some minor changes for `video.rs`/`render.rs`

### DIFF
--- a/src/bin/measure.rs
+++ b/src/bin/measure.rs
@@ -73,6 +73,8 @@ async fn render_views(
             walltime: Duration::from_secs(100),
             scene_center: None,
             scene_extend: None,
+            background_color: wgpu::Color::BLACK,
+            resolution: resolution,
         },
         &mut None,
     );
@@ -121,6 +123,8 @@ async fn render_views(
                     walltime: Duration::from_secs(100),
                     scene_center: None,
                     scene_extend: None,
+                    background_color: wgpu::Color::BLACK,
+                    resolution: resolution,
                 },
                 &mut None,
             );

--- a/src/bin/video.rs
+++ b/src/bin/video.rs
@@ -37,6 +37,15 @@ struct Opt {
 
     #[arg(long, default_value_t = 30)]
     fps: u32,
+
+    #[arg(long, default_value_t = 2880)]
+    output_width: u32,
+
+    #[arg(long, default_value_t = 4320)]
+    output_height: u32,
+
+    #[arg(long, default_value_t = 0)]
+    beginning_scale_up_seconds: u64,
 }
 
 async fn render_tracking_shot(
@@ -48,10 +57,13 @@ async fn render_tracking_shot(
     video_out: &PathBuf,
     duration: Option<Duration>,
     fps: u32,
+    output_width: u32,
+    output_height: u32,
+    beginning_scale_up_seconds: u64,
 ) {
     println!("saving video to '{}'", video_out.to_string_lossy());
 
-    let resolution: Vector2<u32> = Vector2::new(1024, 1024) * 2;
+    let resolution: Vector2<u32> = Vector2::new(output_width, output_height);
 
     let target = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("render texture"),
@@ -126,9 +138,11 @@ async fn render_tracking_shot(
                 mip_splatting: None,
                 kernel_size: None,
                 clipping_box: None,
-                walltime: state_time,
+                walltime: state_time + Duration::from_secs(beginning_scale_up_seconds),
                 scene_center: None,
                 scene_extend: None,
+                background_color: wgpu::Color::BLACK,
+                resolution: resolution,
             },
             &mut None,
         );
@@ -198,6 +212,9 @@ async fn main() {
         &opt.video_out,
         opt.duration.map(Duration::from_secs_f32),
         opt.fps,
+        opt.output_width,
+        opt.output_height,
+        opt.beginning_scale_up_seconds,
     )
     .await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,6 +839,32 @@ pub async fn open_window<R: Read + Seek + Send + Sync + 'static>(
                     _=>{}
                 }
             }
+            WindowEvent::Touch(touch) => {
+                //println!("Touch {}/{}/{}", touch.id, touch.location.x, touch.location.y);
+                match touch.phase
+                {
+                    winit::event::TouchPhase::Started => {
+                        //println!("start");
+                        state.controller.touched_count += 1; 
+                        if state.controller.touched_count == 1 {
+                            state.controller.last_touch.x = touch.location.x as f32; 
+                            state.controller.last_touch.y = touch.location.y as f32;
+                            state.controller.last_touch.z = touch.id as f32;
+                        } 
+                        else if state.controller.touched_count == 2 {
+                            state.controller.last_touch_2.x = touch.location.x as f32; 
+                            state.controller.last_touch_2.y = touch.location.y as f32;
+                            state.controller.last_touch_2.z = touch.id as f32;
+                        }
+                    },
+                    winit::event::TouchPhase::Ended => {
+                        //println!("end");
+                        state.controller.touched_count -= 1;
+                    },
+                    winit::event::TouchPhase::Moved =>  state.controller.process_touch(touch.id as f32, touch.location.x as f32, touch.location.y as f32),
+                    winit::event::TouchPhase::Cancelled => state.controller.touched_count = 0,
+                }
+            }
             WindowEvent::RedrawRequested => {
                 if !config.no_vsync{
                     // make sure the next redraw is called with a small delay


### PR DESCRIPTION
1. add touchscreen support (rotate/zoom) for `viewer.rs`, tested on indows and Android phone.

2. add parameter `output_width`/`output_height` for `video.rs` and `render.rs`, for setting output images' size.

3. add parameter `beginning_scale_up_seconds` for `video.rs`, for setting the beginning time of rendering to avoid points scaling up.